### PR TITLE
Fix regression and formatter

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -2,11 +2,11 @@
   <h3>Single value</h3>
 </div>
 
-<pre>&lt;nouislider [min]=&quot;0&quot; [max]=&quot;10&quot; [step]=&quot;0.05&quot; [(ngModel)]=&quot;someValue&quot; (ngModelChange)=&quot;onChange($event)&quot; [disabled]=&quot;disabled&quot;&gt;&lt;/nouislider&gt;</pre>
+<pre>&lt;nouislider [min]=&quot;-10&quot; [max]=&quot;10&quot; [step]=&quot;0.05&quot; [(ngModel)]=&quot;someValue&quot; (ngModelChange)=&quot;onChange($event)&quot; [disabled]=&quot;disabled&quot;&gt;&lt;/nouislider&gt;</pre>
 
 <code>someValue: {{ someValue | json }}</code>
 
-<nouislider [min]="0" [max]="10" [step]="0.05" [(ngModel)]="someValue" (ngModelChange)="onChange($event)" [disabled]="disabled"></nouislider>
+<nouislider [min]="-10" [max]="10" [step]="0.05" [(ngModel)]="someValue" (ngModelChange)="onChange($event)" [disabled]="disabled"></nouislider>
 
 <div class="btn-group">
   <button type="button" class="btn btn-primary" [disabled]="disabled" (click)="changeSomeValue(-1)">-1</button>

--- a/src/nouislider.ts
+++ b/src/nouislider.ts
@@ -15,11 +15,11 @@ import {
   NG_VALUE_ACCESSOR
 } from '@angular/forms';
 
-export function toValue(value: string[]): any | any[] {
+export function toValue(value: string[]): number|number[] {
   if (value.length == 1) {
-    return value[0];
+    return parseFloat(value[0]);
   } else if (value.length > 1) {
-    return value;
+    return value.map(parseFloat);
   } else {
     return 0;
   }

--- a/src/nouislider.ts
+++ b/src/nouislider.ts
@@ -32,11 +32,11 @@ export interface NouiFormatter {
 
 export class DefaultFormatter implements NouiFormatter {
   to(value: any): any {
-    return parseFloat(value);
+    return parseFloat(value).toFixed(2);
   };
 
   from(value: any): any {
-    return parseFloat(value).toFixed(2);
+    return parseFloat(this.to(value));
   }
 }
 

--- a/test/nouislider.spec.ts
+++ b/test/nouislider.spec.ts
@@ -14,16 +14,16 @@ describe('Default Formatter', () => {
   }));
 
   describe('to', () => {
-    it('should transform strings to numbers', () => {
-      expect(formatter.to('0')).toEqual(0);
-      expect(formatter.to('1')).toEqual(1);
+    it('should transform numbers to strings with default formatting', () => {
+      expect(formatter.to(0)).toEqual('0.00');
+      expect(formatter.to(1)).toEqual('1.00');
     });
   });
 
   describe('from', () => {
-    it('should transform numbers to strings', () => {
-      expect(formatter.from(0)).toEqual('0.00');
-      expect(formatter.from(1)).toEqual('1.00');
+    it('should transform strings with default formatting to numbers', () => {
+      expect(formatter.from('0.00')).toEqual(0);
+      expect(formatter.from('1.00')).toEqual(1);
     });
   });
 });
@@ -67,7 +67,7 @@ describe('Nouislider Component', () => {
         start: 5,
         step: 0.05,
         range: {
-          min: 0,
+          min: -10,
           max: 10
         },
         format: {
@@ -290,7 +290,7 @@ describe('Nouislider Component', () => {
   selector: 'test-single-slider',
   template: `
     <nouislider
-      [min]="0"
+      [min]="-10"
       [max]="10"
       [step]="0.05"
       [(ngModel)]="someValue"


### PR DESCRIPTION
Hi,

I have found an important regression in the latest version. Updating the slider does not work properly when its range is negative. You can easily observe the wrong behavior by setting `[min]="-10"` in the "Single value" example of your demo.

I have tracked down the problem, and I found it originates in the implementation for the `DefaultFormatter`. I think the methods `to()` and `from()` are supposed to be inverted. Indeed, the method `to()` is used to convert the internal slider representation (e.g. `42.0`) _to_ a string representation to be displayed to the user (e.g. `"42 mA"`). Conversely, `from()` is used to convert _from_ a string --- input by the user --- to the internal slider representation (float).

Here is my proposed fix. Hope this helps.