### PR TITLE
Allow installation with angular4

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
     "url": "https://github.com/tb/ng2-nouislider/issues"
   },
   "devDependencies": {
-    "@angular/common": "2.4.2",
-    "@angular/compiler": "2.4.2",
-    "@angular/compiler-cli": "^2.4.2",
-    "@angular/core": "2.4.2",
-    "@angular/forms": "2.4.2",
-    "@angular/platform-browser": "2.4.2",
-    "@angular/platform-browser-dynamic": "2.4.2",
-    "@angular/platform-server": "2.4.2",
+    "@angular/common": "2.4.2 || ^4.0.0",
+    "@angular/compiler": "2.4.2 || ^4.0.0",
+    "@angular/compiler-cli": "^2.4.2 || ^4.0.0",
+    "@angular/core": "2.4.2 || ^4.0.0",
+    "@angular/forms": "2.4.2 || ^4.0.0",
+    "@angular/platform-browser": "2.4.2 || ^4.0.0",
+    "@angular/platform-browser-dynamic": "2.4.2 || ^4.0.0",
+    "@angular/platform-server": "2.4.2 || ^4.0.0",
     "css-loader": "^0.23.1",
     "es6-shim": "^0.35.0",
     "gh-pages": "^0.11.0",
@@ -66,8 +66,8 @@
     "zone.js": "^0.7.2"
   },
   "peerDependencies": {
-    "@angular/common": "^2.0.0",
-    "@angular/core": "^2.0.0",
+    "@angular/common": "^2.0.0 || ^4.0.0",
+    "@angular/core": "^2.0.0 || ^4.0.0",
     "nouislider": "^9.0.0"
   }
 }


### PR DESCRIPTION
Remove warning during install via npm with angular 4
```
warning "ng2-nouislider@1.6.0" has incorrect peer dependency "@angular/common@^2.0.0".
warning "ng2-nouislider@1.6.0" has incorrect peer dependency "@angular/core@^2.0.0".
```