### PR TITLE
Allow nouislider 10 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "1.7.0",
     "node-sass": "^3.7.0",
-    "nouislider": "^9.0.0",
+    "nouislider": "^10.0.0",
     "raw-loader": "^0.5.1",
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.1",
@@ -68,6 +68,6 @@
   "peerDependencies": {
     "@angular/common": "^2.0.0 || ^4.0.0",
     "@angular/core": "^2.0.0 || ^4.0.0",
-    "nouislider": "^9.0.0"
+    "nouislider": "^9.0.0 || ^10.0.0"
   }
 }

--- a/test/nouislider.spec.ts
+++ b/test/nouislider.spec.ts
@@ -80,7 +80,8 @@ describe('Nouislider Component', () => {
           from: function (value: any) : any {
             return parseFloat(value);
           }
-        }
+        },
+        ariaFormat: {}
       };
 
       expect(JSON.parse(JSON.stringify(sliderInstance['config']))).toEqual(JSON.parse(JSON.stringify(defaultOptions)));
@@ -162,7 +163,8 @@ describe('Nouislider Component', () => {
           from: function (value: any) : any {
             return parseFloat(value);
           }
-        }
+        },
+        ariaFormat: {}
       };
 
       expect(JSON.parse(JSON.stringify(sliderInstance['config']))).toEqual(JSON.parse(JSON.stringify(defaultOptions)));
@@ -217,7 +219,8 @@ describe('Nouislider Component', () => {
           from: function (value: any) : any {
             return parseFloat(value);
           }
-        }
+        },
+        ariaFormat: {}
       };
       expect(JSON.parse(JSON.stringify(sliderInstance['config']))).toEqual(JSON.parse(JSON.stringify(defaultOptions)));
       expect(JSON.parse(JSON.stringify(sliderInstance.slider.options))).toEqual(JSON.parse(JSON.stringify(defaultOptions)));
@@ -280,7 +283,8 @@ describe('Nouislider Component', () => {
           from: function (value: any) : any {
             return parseFloat(value);
           }
-        }
+        },
+        ariaFormat: {}
       };
 
       expect(JSON.parse(JSON.stringify(sliderInstance['config']))).toEqual(JSON.parse(JSON.stringify(defaultOptions)));


### PR DESCRIPTION
Everything seems to work ok, the only breaking change in v10 is the change to passive event listeners which I don't think affects this lib.