### PR TITLE
Changed access to DOM element property

### DIFF
--- a/src/nouislider.d.ts
+++ b/src/nouislider.d.ts
@@ -9,7 +9,7 @@ export declare class DefaultFormatter implements NouiFormatter {
     from(value: string): number;
 }
 export declare class NouisliderComponent implements ControlValueAccessor, OnInit, OnChanges {
-    private el;
+    protected el;
     slider: any;
     handles: any[];
     disabled: boolean;


### PR DESCRIPTION
To allow subclasses to interact with the native element, change the access from `private` to `protected`.