### PR TITLE
fix: allow nouislider 11 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "1.7.0",
     "node-sass": "^3.7.0",
-    "nouislider": "^10.0.0",
+    "nouislider": "^11.0.0",
     "raw-loader": "^0.5.1",
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.5.2",
@@ -74,6 +74,6 @@
   "peerDependencies": {
     "@angular/common": "^2.0.0 || ^4.0.0 || ^5.0.0",
     "@angular/core": "^2.0.0 || ^4.0.0 || ^5.0.0",
-    "nouislider": "^9.0.0 || ^10.0.0"
+    "nouislider": "^9.0.0 || ^10.0.0 || ^11.0.0"
   }
 }


### PR DESCRIPTION
There are no api breaking changes in v11 so this should be safe: https://github.com/leongersen/noUiSlider/releases