### PR TITLE
Supported direction and padding inputs

### DIFF
--- a/projects/ngx-nouislider/src/lib/ngx-nouislider.component.spec.ts
+++ b/projects/ngx-nouislider/src/lib/ngx-nouislider.component.spec.ts
@@ -44,7 +44,8 @@ describe('Nouislider Component', () => {
         TestRangeSliderComponent,
         TestSingleFormSliderComponent,
         TestRangeFormSliderComponent,
-        TestRangeTooltipFormatterSliderComponent
+        TestRangeTooltipFormatterSliderComponent,
+        TestSingleSliderCustomDirectionPaddingComponent
       ]
     });
   }));
@@ -82,7 +83,9 @@ describe('Nouislider Component', () => {
             return parseFloat(value);
           }
         },
-        ariaFormat: {}
+        ariaFormat: {},
+        direction: 'ltr',
+        padding: 0
       };
 
       expect(JSON.parse(JSON.stringify(sliderInstance.config))).toEqual(JSON.parse(JSON.stringify(defaultOptions)));
@@ -165,7 +168,9 @@ describe('Nouislider Component', () => {
             return parseFloat(value);
           }
         },
-        ariaFormat: {}
+        ariaFormat: {},
+        direction: 'ltr',
+        padding: 0
       };
 
       expect(JSON.parse(JSON.stringify(sliderInstance.config))).toEqual(JSON.parse(JSON.stringify(defaultOptions)));
@@ -221,7 +226,9 @@ describe('Nouislider Component', () => {
             return parseFloat(value);
           }
         },
-        ariaFormat: {}
+        ariaFormat: {},
+        direction: 'ltr',
+        padding: 0
       };
       expect(JSON.parse(JSON.stringify(sliderInstance.config))).toEqual(JSON.parse(JSON.stringify(defaultOptions)));
       expect(JSON.parse(JSON.stringify(sliderInstance.slider.options))).toEqual(JSON.parse(JSON.stringify(defaultOptions)));
@@ -309,7 +316,9 @@ describe('Nouislider Component', () => {
             return parseFloat(value);
           }
         },
-        ariaFormat: {}
+        ariaFormat: {},
+        direction: 'ltr',
+        padding: 0
       };
 
       expect(JSON.parse(JSON.stringify(sliderInstance.config))).toEqual(JSON.parse(JSON.stringify(defaultOptions)));
@@ -331,6 +340,53 @@ describe('Nouislider Component', () => {
       expect(componentInstance.form.value).toEqual({ range: [4, 6] });
     }));
   });
+
+  describe('single slider with custom padding and direction inputs', () => {
+    let fixture: ComponentFixture<TestSingleSliderCustomDirectionPaddingComponent>;
+    let componentInstance: TestSingleSliderCustomDirectionPaddingComponent;
+    let sliderDebugElement: DebugElement;
+    let sliderNativeElement: HTMLElement;
+    let sliderInstance: NouisliderComponent;
+
+    beforeEach(async(() => {
+      fixture = TestBed.createComponent(TestSingleSliderCustomDirectionPaddingComponent);
+      componentInstance = fixture.debugElement.componentInstance;
+      sliderDebugElement = fixture.debugElement.query(By.directive(NouisliderComponent));
+      sliderNativeElement = sliderDebugElement.nativeElement;
+      sliderInstance = sliderDebugElement.componentInstance;
+      spyOn(componentInstance, 'onEvent');
+      fixture.detectChanges();
+    }));
+
+    it('should set custom padding and direction', () => {
+      const defaultOptions = {
+        start: 5,
+        step: 0.05,
+        range: {
+          min: -10,
+          max: 10
+        },
+        format: {
+          to(value: any): any {
+            return value;
+          },
+          from(value: any): any {
+            return parseFloat(value);
+          }
+        },
+        ariaFormat: {},
+        direction: 'rtl',
+        padding: [1, 1]
+      };
+
+      expect(JSON.parse(JSON.stringify(sliderInstance.config))).toEqual(
+        JSON.parse(JSON.stringify(defaultOptions))
+      );
+      expect(JSON.parse(JSON.stringify(sliderInstance.slider.options))).toEqual(
+        JSON.parse(JSON.stringify(defaultOptions))
+      );
+});
+});
 });
 
 @Component({
@@ -433,4 +489,26 @@ class TestRangeFormSliderComponent {
   constructor(private formBuilder: FormBuilder) {
     this.form = this.formBuilder.group({ range: [[2, 8]] });
   }
+}
+
+@Component({
+  selector: 'test-single-slider-custom-direction-padding',
+  template: `
+    <nouislider
+      [min]="-10"
+      [max]="someLimit"
+      [step]="0.05"
+      [direction]="'rtl'"
+      [padding]="[1, 1]"
+      [(ngModel)]="someValue"
+      (ngModelChange)="onEvent('ngModelChange', $event)"
+      (change)="onEvent('change', $event)"
+      (set)="onEvent('set', $event)"
+    ></nouislider>
+  `
+})
+class TestSingleSliderCustomDirectionPaddingComponent {
+  public someValue = 5;
+  public someLimit = 10;
+  public onEvent(event: string, value: number) {}
 }

--- a/projects/ngx-nouislider/src/lib/ngx-nouislider.component.ts
+++ b/projects/ngx-nouislider/src/lib/ngx-nouislider.component.ts
@@ -75,6 +75,8 @@ export class NouisliderComponent implements ControlValueAccessor, OnInit, OnChan
   @Input() public onKeydown: any;
   @Input() public formControl: FormControl;
   @Input() public tooltips: Array<any>;
+  @Input() public direction: 'ltr' | 'rtl';
+  @Input() public padding: number | number[];
   @Output() public change: EventEmitter<any> = new EventEmitter(true);
   @Output() public update: EventEmitter<any> = new EventEmitter(true);
   @Output() public slide: EventEmitter<any> = new EventEmitter(true);
@@ -100,8 +102,11 @@ export class NouisliderComponent implements ControlValueAccessor, OnInit, OnChan
       range: this.range || this.config.range || {min: this.min, max: this.max},
       tooltips: this.tooltips,
       snap: this.snap,
-      animate: this.animate
-    }));
+      animate: this.animate,
+      direction: this.direction || this.config.direction || 'ltr',
+      padding: this.padding || this.config.padding || 0
+      })
+    );
     inputsConfig.tooltips = this.tooltips || this.config.tooltips;
     inputsConfig.format = this.format || this.config.format || new DefaultFormatter();
 


### PR DESCRIPTION
Hello,

both [`direction`](https://refreshless.com/nouislider/slider-options/#section-direction) and [`padding`](https://refreshless.com/nouislider/slider-options/#section-padding) are options from noUiSlider. We could define those inside a config but now we can also define them in HTML.


Happy coding 🎉